### PR TITLE
Enable NoSignalHandling

### DIFF
--- a/server/server_impl.go
+++ b/server/server_impl.go
@@ -62,6 +62,7 @@ func (s *serverImpl) Start(handler http.Handler, applicationConfig *config.App) 
 		Timeout:           time.Duration(applicationConfig.OutstandingRequestTimeoutMs) * time.Second,
 		Server:            s.server,
 		ShutdownInitiated: s.shutdownHookFunc,
+		NoSignalHandling: true,
 	}
 
 	return s.gracefulServer.ListenAndServe()


### PR DESCRIPTION
The `graceful` library attempts to capture and handle signals in their server wrapper. This clashes with the signal handler from `fx`, which is managing the lifecycle of the entire application - this means that `ctrl+c` doesn't shut the app down. 

Instead, I would propose disabling the `graceful` signal handler, and using `fx` to send the shutdown signal like so:

```go
	lc.Append(fx.Hook{
		OnStart: func(context.Context) error {
			go func() {
				if err := srv.Start(router, &cfg); err != nil {
					panic(err)
				}
			}()
			return nil
		},
		OnStop: func(ctx context.Context) error {
			srv.Stop() <- true
			return nil
		},
	})
```